### PR TITLE
provide do not create new *AuthenticationServiceImpl instance

### DIFF
--- a/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/EmailAuthenticationServiceImpl.java
+++ b/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/EmailAuthenticationServiceImpl.java
@@ -2,6 +2,9 @@ package dev.agitrubard.factory.service.impl;
 
 import dev.agitrubard.factory.service.TwoFactorAuthenticationService;
 
+import org.springframework.stereotype.Service;
+
+@Service(value = "EMAIL")
 class EmailAuthenticationServiceImpl implements TwoFactorAuthenticationService {
 
     @Override

--- a/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/PassKeyAuthenticationServiceImpl.java
+++ b/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/PassKeyAuthenticationServiceImpl.java
@@ -2,11 +2,14 @@ package dev.agitrubard.factory.service.impl;
 
 import dev.agitrubard.factory.service.TwoFactorAuthenticationService;
 
+import org.springframework.stereotype.Service;
+
+@Service(value = "PASSKEY")
 class PassKeyAuthenticationServiceImpl implements TwoFactorAuthenticationService {
 
-    @Override
-    public String authenticate() {
-        return "User authenticating via Passkey...";
-    }
+  @Override
+  public String authenticate() {
+    return "User authenticating via Passkey...";
+  }
 
 }

--- a/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/SmsAuthenticationServiceImpl.java
+++ b/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/SmsAuthenticationServiceImpl.java
@@ -2,11 +2,14 @@ package dev.agitrubard.factory.service.impl;
 
 import dev.agitrubard.factory.service.TwoFactorAuthenticationService;
 
+import org.springframework.stereotype.Service;
+
+@Service(value = "SMS")
 class SmsAuthenticationServiceImpl implements TwoFactorAuthenticationService {
 
-    @Override
-    public String authenticate() {
-        return "User authenticating via SMS...";
-    }
+  @Override
+  public String authenticate() {
+    return "User authenticating via SMS...";
+  }
 
 }

--- a/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/TwoFactorAuthenticationServiceFactoryImpl.java
+++ b/pattern/factory/src/main/java/dev/agitrubard/factory/service/impl/TwoFactorAuthenticationServiceFactoryImpl.java
@@ -3,25 +3,28 @@ package dev.agitrubard.factory.service.impl;
 import dev.agitrubard.factory.model.enums.TwoFactorAuthenticationType;
 import dev.agitrubard.factory.service.TwoFactorAuthenticationService;
 import dev.agitrubard.factory.service.TwoFactorAuthenticationServiceFactory;
-import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
 
 @Component
 class TwoFactorAuthenticationServiceFactoryImpl implements TwoFactorAuthenticationServiceFactory {
 
-    @Override
-    public TwoFactorAuthenticationService create(TwoFactorAuthenticationType twoFactorAuthenticationType) {
+  private final ApplicationContext applicationContext;
 
-        TwoFactorAuthenticationType authenticationType = Optional.ofNullable(twoFactorAuthenticationType)
-                .orElse(TwoFactorAuthenticationType.EMAIL);
+  public TwoFactorAuthenticationServiceFactoryImpl(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
 
-        return switch (authenticationType) {
-            case PASSKEY -> new PassKeyAuthenticationServiceImpl();
-            case SMS -> new SmsAuthenticationServiceImpl();
-            case EMAIL -> new EmailAuthenticationServiceImpl();
-        };
+  @Override
+  public TwoFactorAuthenticationService create(TwoFactorAuthenticationType twoFactorAuthenticationType) {
 
-    }
+    TwoFactorAuthenticationType authenticationType = Optional.ofNullable(twoFactorAuthenticationType)
+        .orElse(TwoFactorAuthenticationType.EMAIL);
+
+    return (TwoFactorAuthenticationService) applicationContext.getBean(authenticationType.name());
+  }
 
 }


### PR DESCRIPTION
annotated EmailAuthenticationServiceImpl, SmsAuthenticationServiceImpl and PassKeyAuthenticationServiceImpl as spring service so when we want to create TwoFactorAuthenticationService we can get from spring application context. therefore, we do not create new instance of any auth *AuthenticationServiceImpl